### PR TITLE
add --magic_pre_flatten

### DIFF
--- a/klayout_pex/kpex_cli.py
+++ b/klayout_pex/kpex_cli.py
@@ -267,6 +267,9 @@ class KpexCLI:
         group_magic.add_argument("--magic_merge", dest='magic_merge_mode',
                                  default=MagicMergeMode.DEFAULT, type=MagicMergeMode, choices=list(MagicMergeMode),
                                  help=render_enum_help(topic='magic_merge', enum_cls=MagicMergeMode))
+        group_magic.add_argument("--magic_pre_flatten", dest='magic_pre_flatten',
+                                 action='store_true', default=False,
+                                 help="Flatten GDS before reading it with Magic (default is %(default)s).")
 
         group_25d = main_parser.add_argument_group("2.5D options")
         group_25d.add_argument("--mode", dest='pex_mode',
@@ -597,7 +600,23 @@ class KpexCLI:
 
         os.makedirs(magic_run_dir, exist_ok=True)
 
-        prepare_magic_script(gds_path=args.effective_gds_path,
+        layout = kdb.Layout()
+        layout.read(args.effective_gds_path)
+
+        if args.magic_pre_flatten:
+            tops = list(layout.top_cells())
+            if not tops:
+                raise Exception("No top cells found in the input layout.")
+            for top in tops:
+                top.flatten(True)
+            #flattened_gds_path=magic_run_dir+"/"+args.effective_cell_name+".gds"
+            flattened_gds_path=os.path.join(magic_run_dir, f"{args.effective_cell_name}.gds")
+            layout.write(flattened_gds_path)
+            gds_path = flattened_gds_path
+        else:
+            gds_path = args.effective_gds_path
+
+        prepare_magic_script(gds_path=gds_path,
                              cell_name=args.effective_cell_name,
                              run_dir_path=magic_run_dir,
                              script_path=magic_script_path,
@@ -616,9 +635,6 @@ class KpexCLI:
                   log_path=magic_log_path)
 
         magic_pex_run = parse_magic_pex_run(Path(magic_run_dir))
-
-        layout = kdb.Layout()
-        layout.read(args.effective_gds_path)
 
         report = rdb.ReportDatabase('')
         magic_log_analyzer = MagicLogAnalyzer(magic_pex_run=magic_pex_run,

--- a/klayout_pex/kpex_cli.py
+++ b/klayout_pex/kpex_cli.py
@@ -609,7 +609,6 @@ class KpexCLI:
                 raise Exception("No top cells found in the input layout.")
             for top in tops:
                 top.flatten(True)
-            #flattened_gds_path=magic_run_dir+"/"+args.effective_cell_name+".gds"
             flattened_gds_path=os.path.join(magic_run_dir, f"{args.effective_cell_name}.gds")
             layout.write(flattened_gds_path)
             gds_path = flattened_gds_path


### PR DESCRIPTION
Fix issue #166 by including a flag `--magic_pre_flatten`.

The default value of this is `False`. Toggle to `True` by giving the flag without arguments.

Using the flag will give Magic a flattened copy of the original GDS file, with all extracted hierarchy levels flattened to prevent via information from breaking connections in Magic PEX. This is a nice to have that makes flow with KLayout with Magic PEX more straightforward with custom cells.

This flag may break hierarchical pins/ports, as pins of all levels are flattened to the same hierarchy. If there is a fix for this, please inform or implement it yourself to make this safer for all users.

Please @martinjankoehler and @tskaar, test this fork when you have the time.